### PR TITLE
wrap html output in a urldecode function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ChangeLog
 =========
+- **1.8.2** Fixed url encoding issue when using sidebar (which the widget requires)
 - **1.8.1** Changed 'comcar.co.uk' to 'legacy.comcar.co.uk', plus bug fixes
 - **1.8.0** Moved the MPG Calculator Vue JS bundle to S3
 - **1.7.0** Added full https compatibility

--- a/wp-comcar-plugins.php
+++ b/wp-comcar-plugins.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Comcar Tools
  * Plugin URI: http://github.com/carmendata/comcar-wordpress-plugin/wiki
  * Description: Includes the Tax Calculator, Vehicle Comparator amd Emissions Footprint Calculator from legacy.comcar.co.uk.
- * Version: 1.8.1
+ * Version: 1.8.2
  * Author: Carmen data
  * Author URI: http://carmendata.co.uk/
  * License: GPL2
@@ -15,7 +15,7 @@
 // ini_set( 'error_reporting', E_ALL );
 // ini_set( 'display_errors', true );
 
-define( "WPComcar_PLUGINVERSION","1.8.1" );
+define( "WPComcar_PLUGINVERSION","1.8.2" );
 
 require_once( __DIR__."/wp-comcar-constants.php" );
 require_once( __DIR__."/admin/wp-comcar-plugins-admin-html.php" );

--- a/wp-comcar-sidebar.php
+++ b/wp-comcar-sidebar.php
@@ -8,5 +8,5 @@
 
 	include $plugin_dir . 'webservices-calls/Tax-Calculator/Car-select.php';
 
-	echo $WPComcar_resultsHTML;
+	echo urldecode($WPComcar_resultsHTML);
 ?>


### PR DESCRIPTION
**Trello**

https://trello.com/c/KTemVCeE/90-goforfinance-and-whatvan-wordpress-plugins-failing

**What is it for**

Wordpress widget failing to get to step 2 of the tax calc

**Changes**

Widget loaded sidebar code that didn't use urldecode

**Setup**

n/a

**Testing**

Log into the wordpress admin panel at https://wordpress.carmendata.co.uk/wp-admin/

- update the comcar wordpress plugins
  - remove the current plugin (not the widget)
  - [download the dev branch here](https://github.com/carmendata/comcar-wordpress-plugin/archive/urldecode-sidebar.zip)
  - install the plugin using the dev branch zip
  - update the widget path in Appearance > Widgets:
![image](https://user-images.githubusercontent.com/1201871/60528675-dd44cf80-9cec-11e9-93b1-58b941bd0734.png)

After all this you should now be able to access step 2 of the tax calculator via the widget